### PR TITLE
Be less shouty when testing

### DIFF
--- a/t/50-invalid-empty-component.t
+++ b/t/50-invalid-empty-component.t
@@ -25,7 +25,7 @@ for my $spec_version (qw[1.3 1.4 1.5 1.6 1.7]) {
         eval { $bom->components->push(SBOM::CycloneDX::Component->new(type => 'library')) };
 
         isnt $@, '';
-        diag $@;
+        note $@;
 
     };
 

--- a/t/50-invalid-missing-component-type.t
+++ b/t/50-invalid-missing-component-type.t
@@ -24,7 +24,7 @@ for my $spec_version (qw[1.3 1.4 1.5 1.6 1.7]) {
         eval { $bom->components->push(SBOM::CycloneDX::Component->new(name => 'acme-library', version => '1.0.0')) };
 
         isnt $@, '';
-        diag $@;
+        note $@;
         is_bom $bom;
         is $bom->spec_version, $spec_version;
 

--- a/t/lib/Test/CycloneDX.pm
+++ b/t/lib/Test/CycloneDX.pm
@@ -50,8 +50,8 @@ sub bom_test_data {
 
     BAIL_OUT("$test_name ($spec_version) not found") unless -f $test_file_path;
 
-    diag("Load $test_file");
-    diag("Spec Version: $spec_version");
+    note("Load $test_file");
+    note("Spec Version: $spec_version");
 
     return decode_json(file_read($test_file_path));
 
@@ -72,8 +72,8 @@ sub is_valid_bom {
     my $bom = shift;
     my @errors = $bom->validate;
 
-    diag $_ for @errors;
     is scalar @errors, 0, sprintf('JSON Schema: Valid CycloneDX %s', $bom->spec_version);
+    diag $_ for @errors;
 
 }
 
@@ -82,8 +82,8 @@ sub isnt_valid_bom {
     my $bom = shift;
     my @errors = $bom->validate;
 
-    diag $_ for @errors;
     isnt scalar @errors, 0, sprintf('JSON Schema: Not Valid CycloneDX %s', $bom->spec_version);
+    note $_ for @errors;
 
 }
 
@@ -91,7 +91,7 @@ sub is_bom {
 
     my $bom = shift;
 
-    diag "$bom";
     isnt "$bom", '', sprintf('Is CycloneDX %s JSON file', $bom->spec_version);
+    note "$bom";
 
 }


### PR DESCRIPTION
Currently the tests are outputting a large amount of data even when things succeed. This can make it really hard to identify failures.

This patch downgrades diag to note in such cases, so that in prove / make test it is hidden, but when running tests manually it's still visible.